### PR TITLE
Rename package to go-lookslike in mod/imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/lookslike
+module github.com/elastic/go-lookslike
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/lookslike/compiled_schema.go
+++ b/lookslike/compiled_schema.go
@@ -18,9 +18,9 @@
 package lookslike
 
 import (
-	"github.com/elastic/lookslike/lookslike/isdef"
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/isdef"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 type flatValidator struct {

--- a/lookslike/core.go
+++ b/lookslike/core.go
@@ -24,10 +24,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/elastic/lookslike/lookslike/isdef"
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
-	"github.com/elastic/lookslike/lookslike/validator"
+	"github.com/elastic/go-lookslike/lookslike/isdef"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/validator"
 )
 
 // Compose combines multiple SchemaValidators into a single one.

--- a/lookslike/core_test.go
+++ b/lookslike/core_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/lookslike/lookslike/isdef"
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
-	"github.com/elastic/lookslike/lookslike/validator"
+	"github.com/elastic/go-lookslike/lookslike/isdef"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/validator"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"

--- a/lookslike/doc_test.go
+++ b/lookslike/doc_test.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/elastic/lookslike/lookslike/isdef"
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/isdef"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 func Example() {

--- a/lookslike/isdef/core.go
+++ b/lookslike/isdef/core.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 // IsEqual tests that the given object is equal to the actual object.

--- a/lookslike/isdef/core_test.go
+++ b/lookslike/isdef/core_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lookslike/isdef/dsl.go
+++ b/lookslike/isdef/dsl.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/elastic/lookslike/lookslike/internal/llreflect"
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
-	"github.com/elastic/lookslike/lookslike/validator"
+	"github.com/elastic/go-lookslike/lookslike/internal/llreflect"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/validator"
 )
 
 // Is creates a named IsDef with the given Checker.

--- a/lookslike/isdef/dsl_test.go
+++ b/lookslike/isdef/dsl_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/lookslike/isdef/duration.go
+++ b/lookslike/isdef/duration.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 // IsDuration tests that the given value is a duration.

--- a/lookslike/isdef/int.go
+++ b/lookslike/isdef/int.go
@@ -3,8 +3,8 @@ package isdef
 import (
 	"fmt"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 func intGtChecker(than int) ValueValidator {

--- a/lookslike/isdef/string.go
+++ b/lookslike/isdef/string.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 // isStrCheck is a helper for IsDefs that must assert that the value is a string first.

--- a/lookslike/isdef/time.go
+++ b/lookslike/isdef/time.go
@@ -3,8 +3,8 @@ package isdef
 import (
 	"time"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 )
 
 // IsEqualToTime ensures that the actual value is the given time, regardless of zone.

--- a/lookslike/llpath/path.go
+++ b/lookslike/llpath/path.go
@@ -19,7 +19,7 @@ package llpath
 
 import (
 	"fmt"
-	"github.com/elastic/lookslike/lookslike/internal/llreflect"
+	"github.com/elastic/go-lookslike/lookslike/internal/llreflect"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/lookslike/llresult/results.go
+++ b/lookslike/llresult/results.go
@@ -20,7 +20,7 @@ package llresult
 import (
 	"fmt"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
 )
 
 // Results the results of executing a schema.

--- a/lookslike/llresult/value.go
+++ b/lookslike/llresult/value.go
@@ -17,7 +17,7 @@
 
 package llresult
 
-import "github.com/elastic/lookslike/lookslike/llpath"
+import "github.com/elastic/go-lookslike/lookslike/llpath"
 
 // ValidResult is a convenience value for Valid results.
 func ValidResult(p llpath.Path) *Results {

--- a/lookslike/results_test.go
+++ b/lookslike/results_test.go
@@ -20,8 +20,8 @@ package lookslike
 import (
 	"testing"
 
-	"github.com/elastic/lookslike/lookslike/llpath"
-	"github.com/elastic/lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/lookslike/testslike/testing.go
+++ b/lookslike/testslike/testing.go
@@ -20,8 +20,8 @@ package testslike
 import (
 	"testing"
 
-	"github.com/elastic/lookslike/lookslike/llresult"
-	"github.com/elastic/lookslike/lookslike/validator"
+	"github.com/elastic/go-lookslike/lookslike/llresult"
+	"github.com/elastic/go-lookslike/lookslike/validator"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"

--- a/lookslike/validator/validator.go
+++ b/lookslike/validator/validator.go
@@ -1,6 +1,6 @@
 package validator
 
-import "github.com/elastic/lookslike/lookslike/llresult"
+import "github.com/elastic/go-lookslike/lookslike/llresult"
 
 // Validator is the result of Compile and is run against the map you'd like to test.
 type Validator func(interface{}) *llresult.Results

--- a/lookslike/walk.go
+++ b/lookslike/walk.go
@@ -20,8 +20,8 @@ package lookslike
 import (
 	"reflect"
 
-	"github.com/elastic/lookslike/lookslike/internal/llreflect"
-	"github.com/elastic/lookslike/lookslike/llpath"
+	"github.com/elastic/go-lookslike/lookslike/internal/llreflect"
+	"github.com/elastic/go-lookslike/lookslike/llpath"
 )
 
 type walkObserverInfo struct {


### PR DESCRIPTION
Previously the package was lookslike/lookslike which didn't match the URL structure in github.