### PR TITLE
Correctly handle interface{}/nil targets / expectations

### DIFF
--- a/lookslike/core.go
+++ b/lookslike/core.go
@@ -18,8 +18,6 @@
 package lookslike
 
 import (
-	"errors"
-	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -53,6 +51,11 @@ func Compose(validators ...validator.Validator) validator.Validator {
 func Strict(laxValidator validator.Validator) validator.Validator {
 	return func(actual interface{}) *llresult.Results {
 		res := laxValidator(actual)
+
+		// When validating nil objects the lax validator is by definition sufficient
+		if actual == nil {
+			return res
+		}
 
 		// The inner workings of this are a little weird
 		// We use a hash of dotted paths to track the res
@@ -101,9 +104,12 @@ func compile(in interface{}) (validator.Validator, error) {
 		return compileSlice(in.([]interface{}))
 	case isdef.IsDef:
 		return compileIsDef(in.(isdef.IsDef))
+	case nil:
+		// nil can't be handled by the default case of IsEqual
+		return compileIsDef(isdef.IsNil)
 	default:
-		msg := fmt.Sprintf("Cannot compile definition from %v (%T). Expected one of 'map[string]interface{}', 'Slice', or 'IsDef'", in, in)
-		return nil, errors.New(msg)
+		// By default we just check reflection equality
+		return compileIsDef(isdef.IsEqual(in))
 	}
 }
 

--- a/lookslike/core_test.go
+++ b/lookslike/core_test.go
@@ -504,22 +504,22 @@ func TestPrimitives(t *testing.T) {
 	// Test a bunch of primitive types to ensure that simple matching works.
 	// We can't be exhaustive, this list is merely representative
 	cases := []struct {
-		name string
-		val validator.Validator
-		input interface{}
+		name    string
+		val     validator.Validator
+		input   interface{}
 		success bool
 	}{
 		{
-		"struct success",
-		MustCompile(testyStructy{true, "foo"}),
-		testyStructy{true, "foo"},
-		true,
+			"struct success",
+			MustCompile(testyStructy{true, "foo"}),
+			testyStructy{true, "foo"},
+			true,
 		},
 		{
-		"struct fail",
-		MustCompile(testyStructy{true, "foo"}),
-		testyStructy{false, "foo"},
-		false,
+			"struct fail",
+			MustCompile(testyStructy{true, "foo"}),
+			testyStructy{false, "foo"},
+			false,
 		},
 		{
 			"type mismatch",

--- a/lookslike/isdef/core.go
+++ b/lookslike/isdef/core.go
@@ -104,6 +104,6 @@ var IsNil = Is("is nil", func(path llpath.Path, v interface{}) *llresult.Results
 	return llresult.SimpleResult(
 		path,
 		false,
-		fmt.Sprintf("Value %v is not nil", v),
+		fmt.Sprintf("Value %#v is not nil", v),
 	)
 })

--- a/lookslike/llpath/path.go
+++ b/lookslike/llpath/path.go
@@ -118,6 +118,14 @@ func (p Path) Last() *PathComponent {
 
 // GetFrom takes a map and fetches the given Path from it.
 func (p Path) GetFrom(m interface{}) (value interface{}, exists bool) {
+	// nil values are handled specially. If we're fetching from a nil
+	// there's one case where it exists, when comparing it to another nil.
+	if m == nil {
+		// since another nil would be scalar, we just check that the
+		// path length is 0.
+		return nil, len(p) == 0
+	}
+
 	value = m
 	exists = true
 	for _, pc := range p {
@@ -163,6 +171,12 @@ func (ps InvalidPathString) Error() string {
 // ParsePath parses a Path of form key.[0].otherKey.[1] into a Path object.
 func ParsePath(in string) (p Path, err error) {
 	keyParts := strings.Split(in, ".")
+
+	// We return empty paths for empty strings
+	// Empty paths are valid when working with scalar values
+	if in == "" {
+		return Path{}, nil
+	}
 
 	p = make(Path, len(keyParts))
 	for idx, part := range keyParts {

--- a/lookslike/llpath/path_test.go
+++ b/lookslike/llpath/path_test.go
@@ -305,7 +305,12 @@ func TestParsePath(t *testing.T) {
 			Path{}.ExtendMap("foo").ExtendSlice(0).ExtendMap("bar").ExtendSlice(1).ExtendMap("baz"),
 			false,
 		},
-		// TODO: The validation and testing for this needs to be better
+		{
+			"empty string",
+			"",
+			Path{},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This lets you now validate `MustCompile(interface{})(interface{})` correctly, including nils. Nils used to cause internal errors. This now works as you'd expect.

We essentially treat maps and slices as special cases with rich results, but fall back to simple reflectance equality checks otherwise.