### PR TITLE
Fix false panic printouts / Switch from spew to Utter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
     command:
       - ".buildkite/scripts/gofmt.sh"
     agents:
-      image: golang:1.12
+      image: golang:1.20
       cpu: "8"
       memory: "4G"
 
@@ -17,8 +17,7 @@ steps:
     matrix:
       setup:
         go_version:
-          - "1.12"
-          - "1.15.6"
+          - "1.20"
     command:
       - ".buildkite/scripts/test.sh"
     env:
@@ -35,7 +34,7 @@ steps:
     command:
       - ".buildkite/scripts/prepare-report.sh"
     agents:
-      image: golang:1.15.6
+      image: golang:1.20
       cpu: "8"
       memory: "4G"
     artifact_paths:

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.12', '1.15.6'
+            values '1.20'
           }
         }
         stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,14 @@
 module github.com/elastic/go-lookslike
 
+go 1.21.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/stretchr/testify v1.3.0
+)
+
+require (
+	github.com/kortschak/utter v1.5.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,10 @@ module github.com/elastic/go-lookslike
 
 go 1.21
 
-require (
-	github.com/davecgh/go-spew v1.1.1
-	github.com/stretchr/testify v1.3.0
-)
+require github.com/stretchr/testify v1.8.4
 
 require (
-	github.com/kortschak/utter v1.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/go-lookslike
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/elastic/go-lookslike
 
 go 1.21
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/kortschak/utter v1.5.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kortschak/utter v1.5.0 h1:1vHGHPZmJ6zU5XbfllIAG3eQBoHT97ePrZJ+pT3RoiQ=
+github.com/kortschak/utter v1.5.0/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/kortschak/utter v1.5.0 h1:1vHGHPZmJ6zU5XbfllIAG3eQBoHT97ePrZJ+pT3RoiQ=
-github.com/kortschak/utter v1.5.0/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kortschak/utter v1.5.0 h1:1vHGHPZmJ6zU5XbfllIAG3eQBoHT97ePrZJ+pT3RoiQ=
+github.com/kortschak/utter v1.5.0/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/testslike/testing.go
+++ b/testslike/testing.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/validator"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/kortschak/utter"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +36,7 @@ func Test(t *testing.T, validator validator.Validator, value interface{}) *llres
 		assert.Fail(
 			t,
 			"lookslike could not validate map",
-			"%d errors validating source: \n%s", len(r.Errors()), spew.Sdump(value),
+			"%d errors validating source: \n%s", len(r.Errors()), utter.Sdump(value),
 		)
 	}
 

--- a/testslike/testing.go
+++ b/testslike/testing.go
@@ -18,12 +18,12 @@
 package testslike
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/validator"
 
-	"github.com/kortschak/utter"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,10 +33,11 @@ func Test(t *testing.T, validator validator.Validator, value interface{}) *llres
 	r := validator(value)
 
 	if !r.Valid {
+		marshalled, _ := json.MarshalIndent(value, "", "  ")
 		assert.Fail(
 			t,
 			"lookslike could not validate map",
-			"%d errors validating source: \n%s", len(r.Errors()), utter.Sdump(value),
+			"%d errors validating source: \n%s", len(r.Errors()), marshalled,
 		)
 	}
 

--- a/testslike/testing.go
+++ b/testslike/testing.go
@@ -18,11 +18,11 @@
 package testslike
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/validator"
+	"github.com/kortschak/utter"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,11 +33,10 @@ func Test(t *testing.T, validator validator.Validator, value interface{}) *llres
 	r := validator(value)
 
 	if !r.Valid {
-		marshalled, _ := json.MarshalIndent(value, "", "  ")
 		assert.Fail(
 			t,
 			"lookslike could not validate map",
-			"%d errors validating source: \n%s", len(r.Errors()), marshalled,
+			"%d errors validating source: \n%s", len(r.Errors()), utter.Sdump(value),
 		)
 	}
 

--- a/testslike/testing_test.go
+++ b/testslike/testing_test.go
@@ -1,0 +1,19 @@
+package testslike
+
+import (
+	"testing"
+
+	"github.com/elastic/go-lookslike"
+)
+
+func TestTest(t *testing.T) {
+	validator := lookslike.MustCompile(map[string]interface{}{
+		"foo": "bar",
+		"a":   123,
+	})
+	val := map[string]interface{}{
+		"foo": "bar",
+		"a":   123,
+	}
+	Test(t, validator, val)
+}


### PR DESCRIPTION
Today it's irritating to use this library because of lines like the following in complex beats tests which are cluttered and hard to read

``` 
(string) (len=8) "duration": (mapstr.M) (len=1) (PANIC=runtime error: invalid memory address or nil pointer dereference)
```

This fixes that by switching away from [spew](https://github.com/davecgh/go-spew) to [utter](https://pkg.go.dev/github.com/kortschak/utter?utm_source=godoc), which is an actually maintained fork of spew.

Testing this PR is kinda weird, since you need to see a failing test, which is kinda hard to mock since you need a real `testing.T`. The easiest way would be to modify the new test file `testing_test.go` to fail by adding a new field to `validator` and then run `go test .` and look at the output. Unfortunately you lose the type details with JSON output, however the output is much more readable and compact, type conflicts will be reported when they actually matter by lookslike itself so it's probably a win.


Spew output:

```
andrewvc@Andrews-MacBook-Pro ~/p/g/testslike (use-utter)> go test .
--- FAIL: TestTest (0.00s)
    testing.go:36: 
                Error Trace:    testing.go:36
                Error:          lookslike could not validate map
                Test:           TestTest
                Messages:       1 errors validating source: 
                                (map[string]interface {}) (len=3) {
                                 (string) (len=3) "foo": (string) (len=3) "bar",
                                 (string) (len=1) "y": (string) (len=6) "couher",
                                 (string) (len=1) "a": (int) 123
                                }
    testing.go:44: 
                Error Trace:    testing.go:44
                Error:          Received unexpected error:
                                @Path 'y': objects not equal: actual(string(couher)) != expected(string(ouehrceohr))
                Test:           TestTest
FAIL
FAIL    github.com/elastic/go-lookslike/testslike       0.328s
FAIL
```

Utter output:

```
andrewvc@Andrews-MacBook-Pro ~/p/g/testslike (use-utter) [1]> go test .
--- FAIL: TestTest (0.00s)
    testing.go:36: 
                Error Trace:    testing.go:36
                Error:          lookslike could not validate map
                Test:           TestTest
                Messages:       1 errors validating source: 
                                map[string]interface{}{
                                 string("foo"): string("bar"),
                                 string("y"): string("couher"),
                                 string("a"): int(123),
                                }
    testing.go:44: 
                Error Trace:    testing.go:44
                Error:          Received unexpected error:
                                @Path 'y': objects not equal: actual(string(couher)) != expected(string(ouehrceohr))
                Test:           TestTest
FAIL
FAIL    github.com/elastic/go-lookslike/testslike       0.378s
FAIL
```