### PR TITLE
Only require go 1.18.0+

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.20'
+            values '1.18'
           }
         }
         stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/go-lookslike
 
-go 1.18.0
+go 1.18
 
 require (
 	github.com/kortschak/utter v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/go-lookslike
 
-go 1.21
+go 1.18.0
 
 require (
 	github.com/kortschak/utter v1.5.0


### PR DESCRIPTION
In the bump to 1.0.0 we accidentally required a cutting edge go which was unnecessary